### PR TITLE
Add mock receipt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "sdx-transform-testform"]
 	path = sdx-transform-testform
 	url = git@github.com:ONSdigital/sdx-transform-testform.git
+[submodule "sdx-mock-receipt"]
+	path = sdx-mock-receipt
+	url = git@github.com:ONSdigital/sdx-mock-receipt.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
   sdx-mock-receipt:
       build: ./sdx-mock-receipt
       ports:
-        - "88:5000"
+        - "8088:5000"
       env_file:
         - common.env
       networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
      depends_on:
        - rabbit
      environment:
-       - RECEIPT_HOST=skip
+       - RECEIPT_HOST=http://sdx-mock-receipt:5000
      env_file:
        - rabbit.env
        - ftp.env
@@ -141,6 +141,14 @@ services:
        - rabbit.env
        - ftp.env
        - common.env
+  sdx-mock-receipt:
+      build: ./sdx-mock-receipt
+      ports:
+        - "88:5000"
+      env_file:
+        - common.env
+      networks:
+        - sdx-env
   console:
      build: ./sdx-console
      depends_on:


### PR DESCRIPTION
**Changes**

Introduce the mock receipt service into compose setup and modify config to receipt to it.

**How to test**

In a compose environment using this branch, pull down the add-to-compose branch for sdx-mock-receipt.

Run a message through and observe log messages for sdx-mock-receipt to check a successful receipt is captured.

**Who can test**

Anyone but @iwootten
