### PR TITLE
Add receipt service auth credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,6 @@ services:
   sdx-collect:
      restart: always
      build: ./sdx-collect
-     ports:
-       - "8080:8080"
      volumes:
        - ./sdx-collect/logs:/usr/src/logs
      depends_on:
@@ -39,6 +37,7 @@ services:
        - rabbit.env
        - ftp.env
        - common.env
+       - receipt.env
      networks:
       - sdx-env
   sdx-decrypt:
@@ -102,7 +101,6 @@ services:
   sdx-downstream:
      build: ./sdx-downstream
      volumes:
-       - ./sdx-downstream/logs:/app/logs
        - ./sdx-downstream/app:/app
      environment:
        - SDX_STORE_URL=http://sdx-store:5000
@@ -143,8 +141,11 @@ services:
       build: ./sdx-mock-receipt
       ports:
         - "8088:5000"
+      volumes:
+        - ./sdx-mock-receipt:/app
       env_file:
         - common.env
+        - receipt.env
       networks:
         - sdx-env
   console:

--- a/receipt.env
+++ b/receipt.env
@@ -1,0 +1,2 @@
+RECEIPT_USER=test
+RECEIPT_PASS=test


### PR DESCRIPTION
**Changes**
- Add HTTP Basic auth credentials to sdx-collect and sdx-mock-receipt

**How to test**
- Test as part of the https://github.com/ONSdigital/sdx-collect/pull/133 pull request

**Who can test**
Anyone but @ajmaddaford
