### PR TITLE
All rabbit dependent services should start on start-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@
 - Remove generation of symmetric keys
 - Remove use of ctp services
 - Remove use of downstream-cora now that downstream is 1 service
+- Removed sftp image 
+- Added new pure-ftpd image

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ update: check-env
 
 start:
 	@ printf "\n[${YELLOW} Bringing up docker compose ${NO_COLOR}]\n"
-	docker-compose run  --rm start_dependencies
+	docker-compose run --rm start_dependencies
 	docker-compose up --no-deps
 
 build: check-env

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ update: check-env
 
 start:
 	@ printf "\n[${YELLOW} Bringing up docker compose ${NO_COLOR}]\n"
-	docker-compose up
+	docker-compose run  --rm start_dependencies
+	docker-compose up --no-deps
 
 build: check-env
 	@ printf "\n[${YELLOW} Refreshing build ${NO_COLOR}]\n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '2.4'
 services:
   rabbit:
     image: rabbitmq:3-management

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 services:
   rabbit:
     image: rabbitmq:3-management
@@ -8,9 +8,12 @@ services:
       - "5672:5672"
       - "15672:15672"
     networks:
-      - sdx-env
+      sdx-env:
+        aliases:
+          - rabbit
+          - sdx-env
   pure-ftpd:
-    image: stilliard/pure-ftpd
+    image: ryangrundy7/ftpd
     volumes:
       - ./pure-ftp:/etc/pure-ftpd
       - ./pure-ftp-structure:/home/ftpusers/ons
@@ -271,6 +274,15 @@ services:
       - env/rabbit.env
     networks:
       - sdx-env
+  start_dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - rabbit
+    command: rabbit:5672
+    networks:
+      sdx-env:
+        aliases:
+          - start_dependencies
 networks:
   sdx-env:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
           - rabbit
           - sdx-env
   pure-ftpd:
-    image: ryangrundy7/ftpd
+    image: onsdigital/pure-ftpd
     volumes:
       - ./pure-ftp:/etc/pure-ftpd
       - ./pure-ftp-structure:/home/ftpusers/ons


### PR DESCRIPTION
With this PR all services that are dependent on rabbit should be able to start on start-up.

To test:
- Run make start and all rabbit dependent services should be up and running

