### PR TITLE
Remove restart always from 3 services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
     networks:
       - sdx-env
   sdx-collect:
-    restart: always
     build: ${SDX_HOME}/sdx-collect
     depends_on:
       - rabbit
@@ -44,7 +43,6 @@ services:
     networks:
       - sdx-env
   sdx-seft-consumer-service:
-    restart: always
     build: ${SDX_HOME}/sdx-seft-consumer-service
     depends_on:
       - rabbit
@@ -76,7 +74,6 @@ services:
     env_file:
      - env/common.env
   sdx-receipt-rrm:
-    restart: always
     build: ${SDX_HOME}/sdx-receipt-rrm
     depends_on:
       - rabbit
@@ -136,11 +133,6 @@ services:
       - env/common.env
     networks:
       - sdx-env
-    # logging:
-    #   driver: syslog
-    #   options:
-    #     syslog-address: "udp://127.0.0.1:5514"
-    #     tag: "sdx-downstream"
   sdx-sequence:
     build: ${SDX_HOME}/sdx-sequence
     ports:


### PR DESCRIPTION
With restart always, on a machine reboot, the 3 services would always restart.  This is fairly useless as you need all of sdx running in order to really get the full use out of it.
Removing this will mean that you'll generally only have an sdx docker container up and running if you're running the full suite via compose