### PR TITLE
Downgrade to what we're using in prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - sdx-env
   db:
-    image: postgres:9.6
+    image: postgres:9.6.2
     volumes:
       - ./postgres/schema.sql:/docker-entrypoint-initdb.d/schema.sql
     env_file:


### PR DESCRIPTION
We're using 9.6.2 in prod but the image we currently use is 9.6.11.
Normally this isn't an issue but a script we wrote worked in development but not in preprod, so we should get these to match to stop this happening again in the future.