### PR TITLE
Add env vars for seft-consumer-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
     build: ${SDX_HOME}/sdx-seft-consumer-service
     depends_on:
       - rabbit
+    environment:
+      - RM_SDX_GATEWAY_URL=http://sdx-mock-receipt:5000/receipts
+      - ANTI_VIRUS_ENABLED=False
     env_file:
       - env/rabbit.env
       - env/ftp.env


### PR DESCRIPTION
https://trello.com/c/SayU5JBT/413-add-functionality-to-test-sdx-seft-consumer-service-using-sdx-console

Needed to add environment variables so seft-consumer service can receipt and have a proper place in the FTP folder to put its documents