### PR TITLE
Remove references to sdx-transform-cora and sdx-ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Remove sdx-ops from repos that are pulled in
+- Remove transform-cora now that transform-cs now handles all transformations
 - Added EDC_QJson folders
 - Add Gateway service build processes
 - Updated keys to match decrypt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX="sdx-"
-REPOS="gateway" "rabbit-monitor" "ops" "collect" "decrypt" "validate" "receipt-rrm" "store" "transform-cs" "transform-cora" "downstream" "sequence" "console" "mock-receipt" "seft-consumer-service" "seft-publisher-service"
+REPOS="gateway" "rabbit-monitor" "collect" "decrypt" "validate" "receipt-rrm" "store" "transform-cs" "downstream" "sequence" "console" "mock-receipt" "seft-consumer-service" "seft-publisher-service"
 
 
 NO_COLOR=\033[0m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,16 +113,6 @@ services:
       - env/common.env
     networks:
       - sdx-env
-  sdx-transform-cora:
-    build: ${SDX_HOME}/sdx-transform-cora
-    ports:
-      - "8084:5000"
-    volumes:
-      - ${SDX_HOME}/sdx-transform-cora:/app
-    env_file:
-      - env/common.env
-    networks:
-      - sdx-env
   sdx-downstream:
     build: ${SDX_HOME}/sdx-downstream
     volumes:


### PR DESCRIPTION
https://trello.com/c/9AI4VaIL/692-switch-off-and-remove-references-to-sdx-transform-cora-5

sdx-transform-cora and sdx-ops aren't needed anymore.  This PR removes references to them.