### PR TITLE
Fixing sdx gateway healthcheck for dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Changed sdx-gatway port mapping
 - Remove sdx-ops from repos that are pulled in
 - Remove transform-cora now that transform-cs now handles all transformations
 - Added EDC_QJson folders

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,7 +186,7 @@ services:
     depends_on:
       - rabbit
     ports:
-      - "8090:5000"
+      - "8087:8087"
     volumes:
       - ${SDX_HOME}/sdx-gateway:/app
     env_file:


### PR DESCRIPTION
To be able to access the healthcheck endpoint for sdx-gateway, I've had to change the port mapping for it to use `8087:8087` instead of `8080:5000`

## Testing
- Run with [sdx-gateway pr](https://github.com/ONSdigital/sdx-gateway/pull/16)
- Run entire suite to make sure everything works correctly
- try going to localhost:8087/healthcheck and you should be able to hit the gateways healthcheck endpoint
